### PR TITLE
chore: Change wording in FAQ-How can I register

### DIFF
--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -44,7 +44,8 @@ const questions = [
     title: "How can I register?",
     description:
       //"Registration is not yet open, but you can join the waitlist on our landing page to be the first to know when it becomes available. We'll also announce it on our website and social media channels once registration opens.",
-      "Registration is now open! To register, you will need to submit your application through the registration form found in the landing page of this website. We will send you a confirmation once your application is accepted.",
+      //"Registration is now open! To register, you will need to submit your application through the registration form found in the landing page of this website. We will send you a confirmation once your application is accepted.",
+      "Registration has already closed! We filled all the available spots almost a month before the event. Thanks for your interest in the hackathon and we hope to see you in next year's edition!",
   },
   {
     title: "What if I'm not a student?",


### PR DESCRIPTION
Show that the registration is closed in the "How can I register?" section of the FAQ.